### PR TITLE
feat: add running script options for dev

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4916,7 +4916,8 @@
     "express-rate-limit": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.2.0.tgz",
-      "integrity": "sha512-T7nul1t4TNyfZMJ7pKRKkdeVJWa2CqB8NA1P8BwYaoDI5QSBZARv5oMS43J7b7I5P+4asjVXjb7ONuwDKucahg=="
+      "integrity": "sha512-T7nul1t4TNyfZMJ7pKRKkdeVJWa2CqB8NA1P8BwYaoDI5QSBZARv5oMS43J7b7I5P+4asjVXjb7ONuwDKucahg==",
+      "requires": {}
     },
     "express-validator": {
       "version": "7.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "npx tsc",
     "start": "npx tsx src/app.ts",
-    "dev": "set NODE_ENV=development && nodemon --watch src --exec node --no-warnings=ExperimentalWarning --loader ts-node/esm ./src/app.ts"
+    "dev:darwin": "export NODE_ENV=development && nodemon --watch src --exec node --no-warnings=ExperimentalWarning --loader ts-node/esm ./src/app.ts",
+    "dev:win": "set NODE_ENV=development && nodemon --watch src --exec node --no-warnings=ExperimentalWarning --loader ts-node/esm ./src/app.ts"
   },
   "keywords": [],
   "author": "Roman Isopenko",


### PR DESCRIPTION
# Pull Request: Add OS-Specific Running Scripts for Development

## Description
This PR fixes an issue where `process.env.NODE_ENV` was returning `undefined` on MacOS during development. The root cause was the difference in how environment variables are set across operating systems. To ensure compatibility, I have added two separate development scripts for Windows and Unix-based systems (MacOS/Linux).

## Changes Made
The `package.json` file now includes OS-specific `dev` scripts:

```json
{
  "scripts": {
    "build": "npx tsc",
    "start": "npx tsx src/app.ts",
    "dev:win": "set NODE_ENV=development && nodemon --watch src --exec node --no-warnings=ExperimentalWarning --loader ts-node/esm ./src/app.ts",
    "dev:darwin": "export NODE_ENV=development nodemon --watch src --exec node --no-warnings=ExperimentalWarning --loader ts-node/esm ./src/app.ts"
  }
}

